### PR TITLE
Emotes are now displayed instead of their word names

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,6 +1,14 @@
 {
     "version": "0.2.0",
     "configurations": [
+        
+        {
+            "name": "Python: Current File",
+            "type": "python",
+            "request": "launch",
+            "program": "${file}",
+            "console": "integratedTerminal"
+        },
         {
             "type": "node",
             "request": "launch",

--- a/js/main.js
+++ b/js/main.js
@@ -83,7 +83,7 @@ twitch.on('message', function(message) {
                     <span class="timestamp"><span class="username">` + JSON.parse(message).User + `</span><span class="posttime">` + moment().format('hh:mm A') + `</span></span>
                     <br>
                         <p class="msg" id="msg-0">
-                        ` + JSON.parse(message).Message + ` <img class="scale" src="https://static-cdn.jtvnw.net/emoticons/v2/191313/default/dark/1.0" />
+                        ` + JSON.parse(message).Message+`
                         </p>
                     </div>
 

--- a/python/Twitch/twitch.py
+++ b/python/Twitch/twitch.py
@@ -52,8 +52,8 @@ def emote_substitution(wordToCheck):
 
 
 def transform_Twitch_Emotes(emoteList, message):
-    for i in emoteList:
-        addEmoteToDictionary(i,message)
+    for emote in emoteList:
+        addEmoteToDictionary(emote,message)
     #Separates the message in words by spaces
     tempStringList=message.split()
     transformedMessage=""

--- a/python/Twitch/twitch.py
+++ b/python/Twitch/twitch.py
@@ -15,62 +15,55 @@ from py_linq import Enumerable
 
 import time
 
-
-MinRange=0
-MaxRange=0
-EmoteList=['']
+Emote_dictionary={}
 EmoteRangeList=['']
-CurrentMessage=""
 
-# def isItOnAnEmoteRange(CurrentMessagePosition):
-    
-#     for i in EmoteRangeList:
-#         if
+#Takes the emote value (ex: '25:0-4') then sets MinRange and MaxRange (ex: 0 and 4)
+# and adds the corresponding word to the dictionary
+def addEmoteToDictionary(emoteValue, entireMessage):
+    MinRange=0
+    MaxRange=0
+    #Right side is the list of ranges where the emote ID is used
+    emoteRangeSide=emoteValue.split(':')[1]
+    #Left side is the ID of the emote
+    emoteIDSide=emoteValue.split(':')[0]
+    #If there is more than one instance of a specific emote, they're separated by commas
+    rangeInstances=emoteRangeSide.split(',')
+    #For every range of the emote, add the identified word to the dictionary
+    for range in rangeInstances:
+        MinRange=range.split('-')[0]
+        MaxRange=range.split('-')[1]
+        #EmoteRangeList.append(rangeInstances)
+        identifiedEmote=entireMessage[int(MinRange):int(MaxRange)+1] #substring identified as emote
+        Emote_dictionary[identifiedEmote]=emoteIDSide #adds the word to the emote dictionary
 
-#     if True:
-#         return True
-#     else:
-#         return False
-
-
-# #Takes the emoticon value (ex: '25:0-4') then sets MinRange and MaxRange (ex: 0 and 4)
-# def getRange_SingleEmote(emoteValue):
-#     #Right side is the list of ranges where the emote ID is used
-#     emoteRangeSide=emoteValue.split(':')[1]
-#     #Left side is the ID of the emote
-#     emoteIDSide=emoteValue.split(':')[0]
-#     #Entire URL of the emote
-#     EmoteList.append(EmoteURLleft+emoteIDSide+EmoteURLright)
-#     #If there is more than one instance of a specific emote, they're separated by commas
-#     rangeInstances=emoteRangeSide.split(',')
-#     #If there is only one instance of the emote, it runs once
-#     #Which means this is STILL INCOMPLETE
-#     for j in rangeInstances:
-#         MinRange=rangeInstances.split('-')[0]
-#         MaxRange=rangeInstances.split('-')[1]
-#         EmoteRangeList.append(rangeInstances)
-
-EmoteURLleft='<img class="scale" src="https://static-cdn.jtvnw.net/emoticons/v2/'
-EmoteURLright='/default/dark/1.0" />'
-
-#receives the dictionary and the word to find an emote for
-#returns the same word if wasnt found
-#returns the constructed URL of the emote image to show
-def emote_substitution(emoteDictionary, emoteName):
-    #If the word exists in the dictionary, return the ID
-    emoteID=123#placeholder
-    if emoteName in emoteDictionary:
-        return EmoteURLleft+emoteDictionary[emoteID]+EmoteURLright
+#Receives the word to find an emote for.
+# returns the same word if it wasnt found in the emote dictionary
+# returns the constructed URL of the emote image to show if it was found
+def emote_substitution(wordToCheck):
+    EmoteURLleft='<img class="scale" src="https://static-cdn.jtvnw.net/emoticons/v2/'
+    EmoteURLright='/default/dark/1.0" />'
+    #Returns the left side of the list entrance... the emote ID
+    if wordToCheck in Emote_dictionary:
+        emoteID=Emote_dictionary[wordToCheck]
+        return EmoteURLleft+emoteID+EmoteURLright
     else:
-        return emoteName
+        return wordToCheck
 
-#Separates the message in words by spaces
-def transform_Twitch_Emotes(message, emoteDictionary):
-    tempString=message.split()
+
+def transform_Twitch_Emotes(emoteList, message):
+    for i in emoteList:
+        addEmoteToDictionary(i,message)
+    #Separates the message in words by spaces
+    tempStringList=message.split()
     transformedMessage=""
-    for x in tempString:
-        transformedMessage+=emote_substitution(emoteDictionary, message)
+    for word in tempStringList:
+        #Each word is checked on the emote_Substitution function. If it is
+        #an emote it returns the corresponding URL to take place of the
+        #original word. If its not an emote, the same word is added
+        transformedMessage+=emote_substitution(word)
         transformedMessage+=" "
+    return transformedMessage
 
 # spawn a new thread to wait for input 
 def get_user_input():
@@ -175,6 +168,7 @@ class TwitchBot(irc.bot.SingleServerIRCBot):
         if emoticonsObject[0]['value'] is not None:
             emoticons =emoticonsObject[0]['value']
             emoticons_list = emoticons.split("/")
+            Message=transform_Twitch_Emotes(emoticons_list,Message)
 
         # Id of sender (to get the logo later)
         userIdObject = twitchMessageObject.where(lambda x: x['key'] == 'user-id')


### PR DESCRIPTION
When a message contains emotes, each corresponding image is now displayed instead of the name of said emote. Can use some optimization, but it works